### PR TITLE
Move hardcoded exception after extracting CFP (fixes crash due to cfp not defined yet)

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -1153,11 +1153,11 @@ class CallForPapers(ConfMetaData):
 			if all(match_num == match_kw) and all(match_num | is_first_call):
 				return sorted_dates.index
 
+		# Otherwise, warn
+		cfp = cfps.loc[maxlen_candidates[0][0], 'cfp']
 		if (cfp.acronym, cfp.year, len(dates)) in self._hardcoded_exceptions:
 			return dates.index
 
-		# Otherwise, warn
-		cfp = cfps.loc[maxlen_candidates[0][0], 'cfp']
 		start, end = dates.loc[maxlen_candidates[0][0], ['conf_start', 'conf_end']]
 		err = (
 			f'{cfp.acronym} {cfp.year} ({start} -- {end})', f'{len(maxlen_candidates[0])} compatible deadlines '

--- a/updater.py
+++ b/updater.py
@@ -1155,7 +1155,7 @@ class CallForPapers(ConfMetaData):
 
 		# Otherwise, warn
 		cfp = cfps.loc[maxlen_candidates[0][0], 'cfp']
-		if (cfp.acronym, cfp.year, len(dates)) in self._hardcoded_exceptions:
+		if (cfp.acronym, cfp.year, len(dates)) in cls._hardcoded_exceptions:
 			return dates.index
 
 		start, end = dates.loc[maxlen_candidates[0][0], ['conf_start', 'conf_end']]


### PR DESCRIPTION
I noticed that the GitHub action is crashing due to a change done in b5538f8aca7530fdd2d034625e32f9b027598576 . The `cfp` variable is created after the condition that checks values in it at https://github.com/lucjaulmes/cfp-timeline/blob/e758764a84c5cf7384d2e491d7c4b31b38fdc32b/updater.py#L1156

This pull request moves the `if` after the `cfp` is populated. I haven't tested it yet, but it seems ok. Thanks for you work :-)